### PR TITLE
Add support to apply migrations at runtime

### DIFF
--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -48,6 +48,14 @@ builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSe
 
 var app = builder.Build();
 
+// Ensure the database is created and up-to-date.
+// Learn more at https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying?tabs=dotnet-core-cli#apply-migrations-at-runtime
+await using (var scope = app.Services.CreateAsyncScope()) 
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    await db.Database.MigrateAsync();
+}
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
This fix ensures that the SQL Azure database is up and running when the application starts. It uses the connection string stored in KeyVault.